### PR TITLE
Remove PHP 7.1 Checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-- 7.1
 - 7.2
 - 7.3
 


### PR DESCRIPTION
The composer.json file requires PHP 7.2 or higher. This checks makes TravisCI report fail on the automated requests to this repository.