### PR TITLE
The composer.json file requires PHP 7.2 or higher.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-- 7.1
 - 7.2
 - 7.3
 


### PR DESCRIPTION
The composer.json file requires PHP 7.2 or higher. The TravisCI configuration requests a build with PHP 7.1, causing the build to fail.