### PR TITLE
Solved namespaces references conflict (Categorys to Categories)

### DIFF
--- a/src/Events/CategoryDeleted.php
+++ b/src/Events/CategoryDeleted.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rinvex\Categorys\Events;
+namespace Rinvex\Categories\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;

--- a/src/Events/CategorySaved.php
+++ b/src/Events/CategorySaved.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rinvex\Categorys\Events;
+namespace Rinvex\Categories\Events;
 
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -10,10 +10,10 @@ use Spatie\Sluggable\SlugOptions;
 use Rinvex\Support\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Model;
 use Rinvex\Cacheable\CacheableEloquent;
-use Rinvex\Categorys\Events\CategorySaved;
+use Rinvex\Categories\Events\CategorySaved;
 use Rinvex\Support\Traits\HasTranslations;
 use Rinvex\Support\Traits\ValidatingTrait;
-use Rinvex\Categorys\Events\CategoryDeleted;
+use Rinvex\Categories\Events\CategoryDeleted;
 use Rinvex\Categories\Builders\EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 


### PR DESCRIPTION
Solved the issue: 
Symfony\Component\Debug\Exception\FatalThrowableError  : Class 'Rinvex\Categories\Events\CategorySaved' not found
changing the namespace plural references (Categorys to Categories)