### PR TITLE
SerializesModels should not have to be used with delete event.

### DIFF
--- a/src/Events/CategoryDeleted.php
+++ b/src/Events/CategoryDeleted.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class CategoryDeleted implements ShouldBroadcast
 {
-    use SerializesModels;
     use InteractsWithSockets;
 
     /**

--- a/src/Events/CategorySaved.php
+++ b/src/Events/CategorySaved.php
@@ -56,7 +56,7 @@ class CategorySaved implements ShouldBroadcast
      */
     public function broadcastAs()
     {
-        return 'rinvex.categories.deleted';
+        return 'rinvex.categories.saved';
     }
 
     /**


### PR DESCRIPTION
SerializesModels should not have to be used with delete events. Because of this trait RE-FETCHES model from DB by ID. But it returns 404 because the record already deleted.


Also fixed typo in CategorySaved.php
https://github.com/rinvex/laravel-categories/issues/64