### PR TITLE
update spatie/laravel-translatable to v6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "kalnoy/nestedset": "^6.0.0",
         "rinvex/laravel-support": "^6.0.0",
         "spatie/laravel-sluggable": "^3.3.0",
-        "spatie/laravel-translatable": "^5.2.0"
+        "spatie/laravel-translatable": "^6.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.31.0",


### PR DESCRIPTION
Adresses #126 

By looking at tests at https://github.com/spatie/laravel-translatable/pull/334 , I can guess that there was no breaking changes.

